### PR TITLE
Fixed the explanation of module division

### DIFF
--- a/Base/5.Arithmetic Operators.md
+++ b/Base/5.Arithmetic Operators.md
@@ -79,4 +79,4 @@ The priority of arithmetical operators in python:
 2. Then multiplication, division, modulus and floor division(*, /, %, //);
 3. And lastly addition and subtraction(+, -).
 ### 2
-Result of module division `n % m`, if `n > m` will be `n`, example: `10 % 12 = 10`.
+Result of module division `n % m`, if `n < m` will be `n`, example: `10 % 12 = 10`.


### PR DESCRIPTION
The explanation had `>` instead of `<` for the special case it was explaining, fixed that